### PR TITLE
Fixed Bewitchment 1.17 integration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ loader_version=0.11.6
 loom_version=0.8-SNAPSHOT
 
 # Mod Properties
-mod_version = 1.7.3+1.17
+mod_version = 1.7.4+1.17
 maven_group = com.williambl.haema
 archives_base_name = haema
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -59,7 +59,7 @@ rats_version=3360105
 geckolib_version=3.0.10
 
 # Bewitchment
-bewitchment_version=3295935
+bewitchment_version=3420704
 
 # FLan
 flan_version=1.17-1.5.4

--- a/src/main/kotlin/com/williambl/haema/compat/bewitchment/BewitchmentIntegration.kt
+++ b/src/main/kotlin/com/williambl/haema/compat/bewitchment/BewitchmentIntegration.kt
@@ -74,10 +74,10 @@ fun registerBewitchmentEventListeners() {
     // Sync vampirism status Bewitchment -> Haema
     OnTransformationSet.EVENT.register(OnTransformationSet { player, transformation ->
         val transformationComponent = TransformationComponent.get(player)
-        if (transformationComponent.transformation == BWTransformations.VAMPIRE) {
+        if (transformation == BWTransformations.VAMPIRE) {
             (player as Vampirable).isVampire = true
             player.isPermanentVampire = true
-        } else if (transformationComponent.transformation != BWTransformations.VAMPIRE && transformationComponent.transformation == BWTransformations.VAMPIRE) {
+        } else if (transformation != BWTransformations.VAMPIRE && transformationComponent.transformation == BWTransformations.VAMPIRE) {
             (player as Vampirable).isVampire = false
             player.isPermanentVampire = false
         }

--- a/src/main/kotlin/com/williambl/haema/compat/bewitchment/BewitchmentIntegration.kt
+++ b/src/main/kotlin/com/williambl/haema/compat/bewitchment/BewitchmentIntegration.kt
@@ -8,8 +8,8 @@ import com.williambl.haema.api.DamageSourceEfficacyEvent
 import com.williambl.haema.api.client.VampireHudAddTextEvent
 import moriyashiine.bewitchment.api.BewitchmentAPI
 import moriyashiine.bewitchment.api.event.*
-import moriyashiine.bewitchment.api.interfaces.entity.BloodAccessor
-import moriyashiine.bewitchment.api.interfaces.entity.TransformationAccessor
+import moriyashiine.bewitchment.api.component.BloodComponent
+import moriyashiine.bewitchment.api.component.TransformationComponent
 import moriyashiine.bewitchment.client.BewitchmentClient
 import moriyashiine.bewitchment.common.registry.BWDamageSources
 import moriyashiine.bewitchment.common.registry.BWPledges
@@ -35,13 +35,13 @@ fun registerBewitchmentEventListeners() {
     // Sync blood changes Haema -> Bewitchment
     BloodChangeEvents.ON_BLOOD_ADD.register(BloodChangeEvents.AddBloodEvent { player, amount ->
         if (BewitchmentAPI.isVampire(player, true)) {
-            (player as BloodAccessor).fillBlood(ceil(amount * 5).toInt(), false)
+            BloodComponent.get(player).fillBlood(ceil(amount * 5).toInt(), false)
         }
     })
     // Sync blood changes Haema -> Bewitchment
     BloodChangeEvents.ON_BLOOD_REMOVE.register(BloodChangeEvents.RemoveBloodEvent { player, amount ->
         if (BewitchmentAPI.isVampire(player, true)) {
-            (player as BloodAccessor).drainBlood(ceil(amount * 5).toInt(), false)
+            BloodComponent.get(player).drainBlood(ceil(amount * 5).toInt(), false)
         }
     })
 
@@ -73,10 +73,11 @@ fun registerBewitchmentEventListeners() {
 
     // Sync vampirism status Bewitchment -> Haema
     OnTransformationSet.EVENT.register(OnTransformationSet { player, transformation ->
-        if (transformation == BWTransformations.VAMPIRE) {
+        val transformationComponent = TransformationComponent.get(player)
+        if (transformationComponent.transformation == BWTransformations.VAMPIRE) {
             (player as Vampirable).isVampire = true
             player.isPermanentVampire = true
-        } else if (transformation != BWTransformations.VAMPIRE && (player as TransformationAccessor).transformation == BWTransformations.VAMPIRE) {
+        } else if (transformationComponent.transformation != BWTransformations.VAMPIRE && transformationComponent.transformation == BWTransformations.VAMPIRE) {
             (player as Vampirable).isVampire = false
             player.isPermanentVampire = false
         }
@@ -100,7 +101,8 @@ fun registerBewitchmentClientEventListeners() {
     VampireHudAddTextEvent.EVENT.register(VampireHudAddTextEvent { player, createText ->
         val texts = mutableListOf<Text>()
         if (BewitchmentAPI.isVampire(player, true)) {
-            if (!(player as TransformationAccessor).alternateForm) {
+            val transformationComponent = TransformationComponent.get(player)
+            if (!(transformationComponent.isAlternateForm)) {
                 texts.add(
                     createText(
                         BewitchmentClient.TRANSFORMATION_ABILITY.boundKeyLocalizedText.copy(),
@@ -112,7 +114,7 @@ fun registerBewitchmentClientEventListeners() {
                 texts.add(
                     createText(
                         BewitchmentClient.TRANSFORMATION_ABILITY.boundKeyLocalizedText.copy(),
-                        BewitchmentAPI.isPledged(player, BWPledges.LILITH) && (player as BloodAccessor).blood > 0,
+                        BewitchmentAPI.isPledged(player, BWPledges.LILITH) && BloodComponent.get(player).blood > 0,
                         TranslatableText("compat.bewitchment.gui.haema.hud.untransform")
                     )
                 )


### PR DESCRIPTION
Please note that I don't have much experience with Kotlin/Java and it's pretty much my first contribution in this field. 

**Also the mod on this pull request seems to have some issues on Vampire -> Human conversion, for some reason https://github.com/williambl/haema/blob/1.17/src/main/kotlin/com/williambl/haema/VampireBloodManager.kt#L73 is still being called when player becomes human (and isVampire & isPermanentVampire are both 0'd by my PR) which results in weird state where player must die in order for changes to actually take effect**

This pull request changes the classes/interfaced changed in Bewitchment.

Pull request is based on changes in Bewitchment from this commit https://github.com/MoriyaShiine/bewitchment/commit/921f1d3ce47ac4805fba0a0941f991e37eca222f#diff-9c4ce57047a2f4f76a453defde63d4f3bfd81952b452152266aa251cb2577806

Before my changes the game crashed on loading the world with the following stacktrace:

```
---- Minecraft Crash Report ----
// Hi. I'm Minecraft, and I'm a crashaholic.

Time: 8/10/21, 12:25 AM
Description: Unexpected error

java.lang.NoClassDefFoundError: moriyashiine/bewitchment/api/interfaces/entity/TransformationAccessor
	at com.williambl.haema.compat.bewitchment.BewitchmentIntegrationKt$registerBewitchmentEventListeners$7.onTransformationSet(BewitchmentIntegrationKt.java:79)
	at moriyashiine.bewitchment.api.event.OnTransformationSet.lambda$static$0(OnTransformationSet.java:12)
	at moriyashiine.bewitchment.api.component.TransformationComponent.setTransformation(TransformationComponent.java:143)
	at moriyashiine.bewitchment.api.component.TransformationComponent.readFromNbt(TransformationComponent.java:63)
	at dev.onyxstudios.cca.api.v3.component.sync.AutoSyncedComponent.applySyncPacket(AutoSyncedComponent.java:101)
	at dev.onyxstudios.cca.internal.entity.CcaEntityClientNw.lambda$initClient$1(CcaEntityClientNw.java:52)
	at java.base/java.util.Optional.ifPresent(Optional.java:178)
	at dev.onyxstudios.cca.internal.entity.CcaEntityClientNw.lambda$initClient$2(CcaEntityClientNw.java:52)
	at net.minecraft.class_1255.method_18859(class_1255.java:151)
	at net.minecraft.class_4093.method_18859(class_4093.java:23)
	at net.minecraft.class_1255.method_16075(class_1255.java:125)
	at net.minecraft.class_1255.method_5383(class_1255.java:110)
	at net.minecraft.class_310.method_1523(class_310.java:1075)
	at net.minecraft.class_310.method_1514(class_310.java:728)
	at net.minecraft.client.main.Main.main(Main.java:217)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:78)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
	at net.fabricmc.loader.game.MinecraftGameProvider.launch(MinecraftGameProvider.java:234)
	at net.fabricmc.loader.launch.knot.Knot.launch(Knot.java:153)
	at net.fabricmc.loader.launch.knot.KnotClient.main(KnotClient.java:28)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:78)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
	at org.multimc.onesix.OneSixLauncher.launchWithMainClass(OneSixLauncher.java:196)
	at org.multimc.onesix.OneSixLauncher.launch(OneSixLauncher.java:231)
	at org.multimc.EntryPoint.listen(EntryPoint.java:143)
	at org.multimc.EntryPoint.main(EntryPoint.java:34)
Caused by: java.lang.ClassNotFoundException: moriyashiine.bewitchment.api.interfaces.entity.TransformationAccessor
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:636)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:182)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:519)
	at net.fabricmc.loader.launch.knot.KnotClassLoader.loadClass(KnotClassLoader.java:175)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:519)
	... 30 more


A detailed walkthrough of the error, its code path and all known details is as follows:
---------------------------------------------------------------------------------------

-- Head --
Thread: Render thread
Stacktrace:
	at com.williambl.haema.compat.bewitchment.BewitchmentIntegrationKt$registerBewitchmentEventListeners$7.onTransformationSet(BewitchmentIntegrationKt.java:79)
	at moriyashiine.bewitchment.api.event.OnTransformationSet.lambda$static$0(OnTransformationSet.java:12)
	at moriyashiine.bewitchment.api.component.TransformationComponent.setTransformation(TransformationComponent.java:143)
	at moriyashiine.bewitchment.api.component.TransformationComponent.readFromNbt(TransformationComponent.java:63)
	at dev.onyxstudios.cca.api.v3.component.sync.AutoSyncedComponent.applySyncPacket(AutoSyncedComponent.java:101)
	at dev.onyxstudios.cca.internal.entity.CcaEntityClientNw.lambda$initClient$1(CcaEntityClientNw.java:52)
	at java.base/java.util.Optional.ifPresent(Optional.java:178)
	at dev.onyxstudios.cca.internal.entity.CcaEntityClientNw.lambda$initClient$2(CcaEntityClientNw.java:52)
	at net.minecraft.class_1255.method_18859(class_1255.java:151)
	at net.minecraft.class_4093.method_18859(class_4093.java:23)
	at net.minecraft.class_1255.method_16075(class_1255.java:125)
```

After my commit the game stopped crashing, review would be appreciated :)

EDIT: Tested on my SMP, turning into a vampire using Bewitchment method worked as expected and hooked the changes via haema. Works lovely! Thank you for a great mod.
EDIT2: The thing that seems to be broken is actually transformation back into the human. When this happens from Bewitchment Haema seems to still keep the vampire effects on the player until their death. When they die the player has to relog into the world kill themselves again and only then Vampire effects are gone for good. I don't know if it's related to my fix (probably is) however I don't know how to fix that either, so I'll let this PR stay until either it's replaced with better fix for this issue or improved and merged